### PR TITLE
Added 60-2 with half moon cam -pattern

### DIFF
--- a/ardustim/src/ardustim.ino
+++ b/ardustim/src/ardustim.ino
@@ -67,6 +67,7 @@ wheels Wheels[MAX_WHEELS] = {
   { dizzy_eight_cylinder_friendly_name, dizzy_eight_cylinder, 0.06667, 8, 360 },
   { sixty_minus_two_friendly_name, sixty_minus_two, 1.0, 120, 360 },
   { sixty_minus_two_with_cam_friendly_name, sixty_minus_two_with_cam, 1.0, 240, 720 },
+  { sixty_minus_two_with_halfmoon_cam_friendly_name, sixty_minus_two_with_halfmoon_cam, 1.0, 240, 720 },
   { thirty_six_minus_one_friendly_name, thirty_six_minus_one, 0.6, 72, 360 },
   { twenty_four_minus_one_friendly_name, twenty_four_minus_one, 0.5, 48, 360 },
   { four_minus_one_with_cam_friendly_name, four_minus_one_with_cam, 0.06667, 16, 720 },

--- a/ardustim/src/wheel_defs.h
+++ b/ardustim/src/wheel_defs.h
@@ -66,6 +66,7 @@
    DIZZY_EIGHT_CYLINDER, /* 4 evenly spaced teeth */
    SIXTY_MINUS_TWO,      /* 60-2 crank only */
    SIXTY_MINUS_TWO_WITH_CAM, /* 60-2 with 2nd trigger on cam */
+   SIXTY_MINUS_TWO_WITH_HALFMOON_CAM, /* 60-2 with "half moon" trigger on cam */
    THIRTY_SIX_MINUS_ONE, /* 36-1 crank only */
    TWENTY_FOUR_MINUS_ONE,
    FOUR_MINUS_ONE_WITH_CAM, /* 4-1 crank + cam */
@@ -120,6 +121,7 @@
  const char dizzy_eight_cylinder_friendly_name[] PROGMEM = "8 cylinder dizzy";
  const char sixty_minus_two_friendly_name[] PROGMEM = "60-2 crank only";
  const char sixty_minus_two_with_cam_friendly_name[] PROGMEM = "60-2 crank and cam";
+ const char sixty_minus_two_with_halfmoon_cam_friendly_name[] PROGMEM = "60-2 crank and 'half moon' cam";
  const char thirty_six_minus_one_friendly_name[] PROGMEM = "36-1 crank only";
  const char twenty_four_minus_one_friendly_name[] PROGMEM = "24-1 crank only";
  const char four_minus_one_with_cam_friendly_name[] PROGMEM = "4-1 crank wheel with cam";
@@ -227,6 +229,36 @@
      1,0,1,0,1,0,1,0,1,0,  /* teeth 31-35 */
      1,2,1,0,1,0,1,0,1,0,  /* teeth 36-40, Cam trigger on latter half of 36th */
      1,0,1,0,1,0,1,0,1,0,  /* teeth 41-45 */
+     1,0,1,0,1,0,1,0,1,0,  /* teeth 46-50 */
+     1,0,1,0,1,0,1,0,1,0,  /* teeth 51-55 */
+     1,0,1,0,1,0,0,0,0,0   /* teeth 56-58 and 59-60 MISSING */
+   };
+ 
+ /* 60-2 pattern with half moon cam trigger (cam input is high for one rotation and low for second rotation),
+  * 50% duty cyctle during normal teeth */
+ const unsigned char sixty_minus_two_with_halfmoon_cam[] PROGMEM = 
+   { /* 60-2 */
+     1,0,1,0,1,0,1,0,1,0,  /* teeth 1-5 */ 
+     1,0,1,0,1,0,1,0,1,0,  /* teeth 6-10 */
+     1,0,1,0,1,0,1,0,1,0,  /* teeth 11-15 */
+     1,0,1,0,1,0,1,0,1,0,  /* teeth 16-20 */
+     1,0,1,0,1,0,1,0,1,0,  /* teeth 21-25 */
+     1,0,1,0,1,0,1,0,1,0,  /* teeth 26-30 */
+     1,0,1,0,1,0,1,0,1,0,  /* teeth 31-35 */
+     1,0,1,0,1,0,1,0,1,0,  /* teeth 36-40 */
+     1,0,1,0,1,0,3,2,3,2,  /* teeth 41-45, Cam trigger goes high on 44th tooth */
+     3,2,3,2,3,2,3,2,3,2,  /* teeth 46-50 */
+     3,2,3,2,3,2,3,2,3,2,  /* teeth 51-55 */
+     3,2,3,2,3,2,2,2,2,2,  /* teeth 56-58 and 59-60 MISSING */
+     3,2,3,2,3,2,3,2,3,2,  /* Second revolution teeth 1-5 */ 
+     3,2,3,2,3,2,3,2,3,2,  /* teeth 6-10 */
+     3,2,3,2,3,2,3,2,3,2,  /* teeth 11-15 */
+     3,2,3,2,3,2,3,2,3,2,  /* teeth 16-20 */
+     3,2,3,2,3,2,3,2,3,2,  /* teeth 21-25 */
+     3,2,3,2,3,2,3,2,3,2,  /* teeth 26-30 */
+     3,2,3,2,3,2,3,2,3,2,  /* teeth 31-35 */
+     3,2,3,2,3,2,3,2,3,2,  /* teeth 36-40 */
+     3,2,3,2,3,2,1,0,1,0,  /* teeth 41-45, Cam trigger goes low on 43th tooth on rotation 2 */
      1,0,1,0,1,0,1,0,1,0,  /* teeth 46-50 */
      1,0,1,0,1,0,1,0,1,0,  /* teeth 51-55 */
      1,0,1,0,1,0,0,0,0,0   /* teeth 56-58 and 59-60 MISSING */


### PR DESCRIPTION
Added 60-2 crank trigger with "half moon" cam pattern. Instead of single small tooth on cam, this pattern has one big tooth that is half cam rotation wide. This is used with hall sensor in many BMW engines at least (m50tu, m52, m52tu, m54 etc.) plus in engines from other manufacturers too and effectively the cam input is high for one engine rotation and low for second engine rotation. So ecu can just poll the cam input at tooth #1 and know the engine phase immediately from the fact that is the cam input high or low. No need to wait for edge trigger and this allows very fast full sequential sync. I know that this cam pattern works well with regular single tooth on cam decoder, but I'm adding the poll level cam decoder to Speeduino for faster syncing, so this PR for Ardustim is just to allow testing of that. The timing of the crank and cam signals are taken from BMW m52 engine.

Example cam trigger wheels:
![image](https://user-images.githubusercontent.com/48950874/91126342-6c106a80-e6ac-11ea-8cd7-62927734f2bd.png)
![image](https://user-images.githubusercontent.com/48950874/91126352-73377880-e6ac-11ea-8507-925e1220cda5.png)

![image](https://user-images.githubusercontent.com/48950874/91222567-0a8de180-e728-11ea-9a6c-846339ec4a0f.png)

