### PR TITLE
Update ST170 pattern to correctly calculate RPM

### DIFF
--- a/ardustim/src/ardustim.ino
+++ b/ardustim/src/ardustim.ino
@@ -112,7 +112,7 @@ wheels Wheels[MAX_WHEELS] = {
   { subaru_six_seven_name_friendly_name, subaru_six_seven, 3.0, 720, 720 },
   { gm_seven_x_friendly_name, gm_seven_x, 1.502, 180, 720 },
   { four_twenty_a_friendly_name, four_twenty_a, 0.6, 144, 720 },
-  { ford_st170_friendly_name, ford_st170, 0.6, 720, 720 },
+  { ford_st170_friendly_name, ford_st170, 3.0, 720, 720 },
   { mitsubishi_3A92_friendly_name, mitsubishi_3A92, 0.6, 144, 720 },
   { Toyota_4AGE_CAS_friendly_name, toyota_4AGE_CAS, 0.333, 144, 720 },
   { Toyota_4AGZE_friendly_name, toyota_4AGZE, 0.333, 144, 720 },


### PR DESCRIPTION
RPM is incorrect in this pattern, reporting approx 1/6th the RPM in tuner studio that Ardu-Stim thinks its generating.