### PR TITLE
Update USB package and fix linux build

### DIFF
--- a/UI/package-lock.json
+++ b/UI/package-lock.json
@@ -4098,9 +4098,9 @@
       }
     },
     "usb": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/usb/-/usb-1.6.3.tgz",
-      "integrity": "sha512-23KYMjaWydACd8wgGKMQ4MNwFspAT6Xeim4/9Onqe5Rz/nMb4TM/WHL+qPT0KNFxzNKzAs63n1xQWGEtgaQ2uw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-1.6.5.tgz",
+      "integrity": "sha512-gLVrerQce+F+TSkWgzXACV07nOw+uBlv0gT3svsqTWWxNDe3ESQBIhss3qonIDArMvWPJp6z3I4hXEDYTmPlHQ==",
       "requires": {
         "bindings": "^1.4.0",
         "nan": "2.13.2",

--- a/UI/package.json
+++ b/UI/package.json
@@ -36,7 +36,7 @@
     "electron-dl": "^1.14.0",
     "request": "^2.88.0",
     "serialport": "^9.0.4",
-    "usb": "^1.6.3"
+    "usb": "^1.6.5"
   },
   "build": {
     "appId": "Test",

--- a/UI/renderer.js
+++ b/UI/renderer.js
@@ -79,18 +79,19 @@ function openSerialPort()
     console.log("Opening serial port: ", e.options[e.selectedIndex].value);
     port = new serialport(e.options[e.selectedIndex].value, { baudRate: 115200 }, function (err) {
         if (err) {
-          return console.log('Error: ', err.message)
+          window.alert(`Error while opening serial port: ${err.message}`);
+          throw err;
         }
-      })
+
+        //Drop the modal dialog until connection is complete
+        modalLoading.init(true);
+        initComplete = false;
+      });
 
     //Update the patterns downdown list
     port.on('open', onSerialConnect);
     //port.on('data', onData);
     //refreshPatternList();
-
-    //Drop the modal dialog until connection is complete
-    modalLoading.init(true);
-    initComplete = false;
 
     // Master listener for all serial actions
     // Switches the port into "flowing mode"


### PR DESCRIPTION
After this [PR](https://github.com/tessel/node-usb/pull/410) build issue with `usb` is finally fixed.

However looks like `serialport` still needs to be rebuilt despite of the binaries being available, not sure why. Good news is that both projects have started working on implementing `N-API` which should stop this madness.

---

Tested on:
- Ubuntu 20.04
- Windows 10
- MacOS 11.2