### PR TITLE
Install with npm ci instead of npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ $ git clone https://github.com/speeduino/Ardu-Stim.git
 $ cd Ardu-Stim/UI
 $
 $ npm install electron-rebuild -g
-$ npm install
+$ npm ci
 $ npm start
 ```


### PR DESCRIPTION
npm ci is meant to be used in deployment. It will use the package-lock.json file to install the depencies and doesn't modify package.json or package-lock.json.