### PR TITLE
Correct enabling of RPM reads

### DIFF
--- a/UI/assets/js/main.js
+++ b/UI/assets/js/main.js
@@ -36,6 +36,8 @@
 				var href = $(this).attr('href');
 
 				// Not a panel link? Bail.
+					if (typeof href === 'undefined')
+						return;
 					if (href.charAt(0) != '#'
 					||	$panels.filter(href).length == 0)
 						return;

--- a/UI/index.html
+++ b/UI/index.html
@@ -20,9 +20,9 @@
 
 				<!-- Nav -->
 					<nav id="nav">
-						<a href="#connect" class="icon fa-plug" onClick="disableRPM()"><span>Connect</span></a>
-						<a id="link_live" class="icon fa-tachometer" onClick="enableRPM()"><span>Dashboard</span></a>
-						<a id="link_config" class="icon fa-sliders-h" onClick="disableRPM()"><span>Config</span></a>
+						<a href="#connect" class="icon fa-plug"><span>Connect</span></a>
+						<a id="link_live" class="icon fa-tachometer"><span>Dashboard</span></a>
+						<a id="link_config" class="icon fa-sliders-h"><span>Config</span></a>
 					</nav>
 
 				<!-- Main -->

--- a/UI/renderer.js
+++ b/UI/renderer.js
@@ -314,7 +314,6 @@ function refreshPattern(data)
       modalLoading.remove();
       //Move to the Live tab
       window.location.hash = '#live';
-      enableRPM();
       initComplete = true;
     }
 
@@ -464,6 +463,7 @@ function animateGauges() {
 var RPMInterval = 0;
 function enableRPM()
 {
+  console.log("Enabling RPM reads");
   if(RPMInterval == 0)
   {
     RPMInterval = setInterval(updateRPM, 100);
@@ -530,6 +530,19 @@ function checkForUpdates()
 
 }
 
+function liveShowHide(mutationsList, observer) {
+  mutationsList.forEach(mutation => {
+    if (mutation.attributeName === 'style') {
+      if (mutation.target.style.display === 'none') {
+        disableRPM();
+      }
+      else {
+        enableRPM();
+      }
+    }
+  })
+}
+
 window.onload = function () 
 {
     refreshSerialPorts();
@@ -538,6 +551,13 @@ window.onload = function ()
     checkForUpdates();
     document.getElementById('versionSpan').innerHTML = remote.app.getVersion();
     //animateGauges();
+
+    //Enable and disabled retrieval of RPM when viewing live panel
+    const liveShowHideObserver = new MutationObserver(liveShowHide);
+    liveShowHideObserver.observe(
+      document.getElementById('live'),
+      { attributes: true }
+    );
 
     usb.on('attach', refreshSerialPorts);
     usb.on('detach', refreshSerialPorts);


### PR DESCRIPTION
Enable and disable RPM reading when showing or hiding the live panel via events. This prevents RPM reads starting when clicking on the live panel before serial has connected. Which in turn would cause Ardu-Stim to lock up when trying to connect (while adding rpm readings as patterns).

Also fix an error when trying to switch to a panel whic hasn't had the href attribute added yet.