### PR TITLE
Prevent patternlist from sending multiple request simultaneously

### DIFF
--- a/UI/index.html
+++ b/UI/index.html
@@ -106,7 +106,7 @@
 									<div class="row">
 										<div class="col-6 col-4-medium col-12-small">Simulated Pattern: </div>
 										<div class="col-1 col-6-medium col-12-small tooltip">
-											<select id="patternSelect" onChange="updatePattern()">
+											<select id="patternSelect" onChange="updatePatternQueue()">
 											</select>
                     </div>
                   </div>

--- a/UI/renderer.js
+++ b/UI/renderer.js
@@ -254,7 +254,7 @@ function refreshPatternNumber(data)
   port.unpipe();
   select.value = patternID;
   console.log("Currently selected Pattern: " + patternID);
-  updatePattern();
+  updatePatternQueue();
 }
 
 function readPattern()
@@ -267,16 +267,29 @@ function readPattern()
 var patternRow = 0;
 var newPattern;
 var patternDegrees;
+
+var nextPatternID = null;
+var currentPatternID = null;
+function updatePatternQueue()
+{
+  nextPatternID = document.getElementById('patternSelect').value;
+
+  if (currentPatternID === null) {
+    updatePattern();
+  }
+}
+
 function updatePattern()
 {
-  var patternID = document.getElementById('patternSelect').value;
+  currentPatternID = nextPatternID;
+  nextPatternID = null;
 
   const parser = port.pipe(new Readline({ delimiter: '\r\n' }));
-  console.log(`Sending 'S' command with pattern ${patternID}`);
+  console.log(`Sending 'S' command with pattern ${currentPatternID}`);
 
   var buffer = new Buffer(2);
   buffer[0] = 0x53; // Ascii 'S'
-  buffer[1] = parseInt(patternID);
+  buffer[1] = parseInt(currentPatternID);
   port.write(buffer); //Send the new pattern ID
 
   //Send the command to save the pattern to EEPROM
@@ -318,7 +331,15 @@ function refreshPattern(data)
       initComplete = true;
     }
 
-  } 
+    if (nextPatternID !== null) {
+      updatePattern();
+    }
+    else {
+      currentPatternID = null;
+    }
+
+  }
+
 }
 
 //Simply redraw the gear pattern using the existing details (Used when the draw style is changed)


### PR DESCRIPTION
When quickly changing between patterns it's possible for the subsequent requests to overwrite the first before the response is recieved. This causes the wrong pattern to be displayed.

Implement a small queue so that every request can finish processing before doing the next one.