### PR TITLE
Remove Python 2.x requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Intended hardware platform is the Arduino Nano or Diecimila.
 ### Pre-Requisites
 
 - NPM - https://www.npmjs.com/get-npm
-- Python 2.x
+- Python
 - Git
 
 ### GUI Installation steps


### PR DESCRIPTION
I can run npm install without issues using Python 3.10 on Windows.