### PR TITLE
Add support for Cam2

### DIFF
--- a/ardustim/ardustim/ardustim.ino
+++ b/ardustim/ardustim/ardustim.ino
@@ -62,7 +62,7 @@ uint16_t sweep_rate = 1;
 sweep_step *SweepSteps;  /* Global pointer for the sweep steps */
 
 wheels Wheels[MAX_WHEELS] = {
-  /* Pointer to friendly name string, pointer to edge array, RPM Scaler, Number of edges in the array, whether the number of edges covers 360 or 720 degrees */
+   /* Pointer to friendly name string, pointer to edge array, RPM Scaler, Number of edges in the array, whether the number of edges covers 360 or 720 degrees */
   { dizzy_four_cylinder_friendly_name, dizzy_four_cylinder, 0.03333, 4, 360 },
   { dizzy_six_cylinder_friendly_name, dizzy_six_cylinder, 0.05, 6, 360 },
   { dizzy_eight_cylinder_friendly_name, dizzy_eight_cylinder, 0.06667, 8, 360 },
@@ -204,11 +204,13 @@ void setup() {
 
 //  pinMode(7, OUTPUT); /* Debug pin for Saleae to track sweep ISR execution speed */
   pinMode(8, OUTPUT); /* Primary (crank usually) output */
-  pinMode(9, OUTPUT); /* Secondary (cam usually) output */
-  pinMode(10, OUTPUT); /* Knock signal for seank, ony on LS1 pattern, NOT IMPL YET */
+  pinMode(9, OUTPUT); /* Secondary (cam1 usually) output */
+  pinMode(10, OUTPUT); /* Tertiary (cam2 usually) output */
+  pinMode(11, OUTPUT); /* Knock signal for seank, ony on LS1 pattern, NOT IMPL YET */
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
-  pinMode(53, OUTPUT); 
-  pinMode(52, OUTPUT); 
+  pinMode(53, OUTPUT); /* crank */
+  pinMode(52, OUTPUT); /* cam 1 */
+  pinMode(51, OUTPUT); /* untested - should be cam2*/
 #endif
 
   sei(); // Enable interrupts

--- a/ardustim/ardustim/wheel_defs.h
+++ b/ardustim/ardustim/wheel_defs.h
@@ -51,6 +51,18 @@
   * Most/all patterns show the pulses you're receive for one revolution
   * of a REAL wheel on a real engine.
   */
+
+  /*
+   * Values to use within a wheel definition. 
+   * 0 means no tooth on any wheel definition
+   * 1 means crank tooth
+   * 2 means cam1 tooth
+   * 4 means cam2 tooth
+   * 
+   * combinations of numbers mean all of the related teeth are present, 
+   * eg  3 means crank and cam1, 5 means crank and cam2, 6 means cam1 and cam2, 7 means crank, cam1 and cam2 
+   */
+
   
   /* Wheel types we know about...
    * This enumerations is the INDEX into the Wheels[] array of structures


### PR DESCRIPTION
Added support for cam2 - tested on a nano. Uses pin 10 for cam2 which needs linking to the appropriate pin on the board (or direct to the arduino).

Extends the values used in the trigger wheel definition to include 4 as cam2. This can be used in conjunction with other values eg 1 for crank to make 5 when both will be triggered high.