### PR TITLE
Update defines.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Ardustim
 
-Ardustim is an engine simulator built on the Arduino platform. It produces simulated crank and cam signals that can be used for testing aftermarket ECUs as well as being a useful tool for the development of firmware for these
+Ardustim is an engine simulator built on the Arduino platform. It produces simulated crank and cam signals that can be used for testing aftermarket or factory ECUs as well as being a useful tool for the development of products or firmware for these.
 
 This version is a fork of the Josh Stewarts Speeduino arduistim [https://github.com/speeduino/Ardu-Stim](https://github.com/speeduino/Ardu-Stim) and that one was a fork of the original by David Andruczyk [https://gitlab.com/libreems-suite/ardu-stim](https://gitlab.com/libreems-suite/ardu-stim) and is intended to provide a more modern, cross platform GUI as well as continued expansion of the trigger pattern library. It was primarily developed for use by the Speeduino community, but can be utilised for testing virtually any aftermarket ECU system. Dale Follett of Twisted Builds LLC has customized this fork for use with the Twisted Builds LLC version of the engine simulator, and have added multiple wheel patterns as requested by customers and users. If you are on any other software version of this ardu-stim software, please feel free to copy/paste any of the wheel patterns I have added and use them as you see fit. There is no guarentee on any of the wheels used or added to this code base, however at time of upload they appear to be correct. Please use and test at your own risk.
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 <div align="center">
 
-![Twisted-Builds-Logo-Color](https://github.com/twisted-builds-llc/Ardu-Stim/assets/58715445/bbe519b5-b80e-47e9-80ce-855e0538daa5)
+<img src="https://github.com/speeduino/wiki.js/raw/master/img/Speeduino%20logo_med.png" alt="Speeduino" width="600" />
 
+[![Release](https://img.shields.io/github/release/speeduino/Ardu-Stim.svg)](https://github.com/speeduino/Ardu-Stim/releases/latest)
+[![License](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://github.com/speeduino/Ardu-Stim/blob/master/LICENSE)
+[![https://img.shields.io/discord/879495735912071269 ](https://img.shields.io/discord/879495735912071269?label=Discord&logo=Discord)](https://discord.gg/YWCEexaNDe)
 
-##### This is the Twisted Builds LLC fork of the Speeduino fork of the ardustim engine simulator.
+##### This is the Speeduino fork of the ardustim engine simulator.
 </div>
 
 ## Ardustim
 
-Ardustim is an engine simulator built on the Arduino platform. It produces simulated crank and cam signals that can be used for testing aftermarket or factory ECUs as well as being a useful tool for the development of products or firmware for these.
+Ardustim is an engine simulator built on the Arduino platform. It produces simulated crank and cam signals that can be used for testing aftermarket ECUs as well as being a useful tool for the development of firmware for these
 
-This version is a fork of the Josh Stewarts Speeduino arduistim [https://github.com/speeduino/Ardu-Stim](https://github.com/speeduino/Ardu-Stim) and that one was a fork of the original by David Andruczyk [https://gitlab.com/libreems-suite/ardu-stim](https://gitlab.com/libreems-suite/ardu-stim) and is intended to provide a more modern, cross platform GUI as well as continued expansion of the trigger pattern library. It was primarily developed for use by the Speeduino community, but can be utilised for testing virtually any aftermarket ECU system. Dale Follett of Twisted Builds LLC has customized this fork for use with the Twisted Builds LLC version of the engine simulator, and have added multiple wheel patterns as requested by customers and users. If you are on any other software version of this ardu-stim software, please feel free to copy/paste any of the wheel patterns I have added and use them as you see fit. There is no guarentee on any of the wheels used or added to this code base, however at time of upload they appear to be correct. Please use and test at your own risk.
+This version is a fork of the original by David Andruczyk [https://gitlab.com/libreems-suite/ardu-stim](https://gitlab.com/libreems-suite/ardu-stim) and is intended to provide a more modern, cross platform GUI as well as continued expansion of the trigger pattern library. It was primarily developed for use by the Speeduino community, but can be utilised for testing virtually any aftermarket ECU system
 
 ## Wiring
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <div align="center">
 
+![Twisted-Builds-Logo-Color](https://github.com/twisted-builds-llc/Ardu-Stim/assets/58715445/bbe519b5-b80e-47e9-80ce-855e0538daa5)
+
+
 ##### This is the Twisted Builds LLC fork of the Speeduino fork of the ardustim engine simulator.
 </div>
 
@@ -7,7 +10,7 @@
 
 Ardustim is an engine simulator built on the Arduino platform. It produces simulated crank and cam signals that can be used for testing aftermarket ECUs as well as being a useful tool for the development of firmware for these
 
-This version is a fork of the original by David Andruczyk [https://gitlab.com/libreems-suite/ardu-stim](https://gitlab.com/libreems-suite/ardu-stim) and is intended to provide a more modern, cross platform GUI as well as continued expansion of the trigger pattern library. It was primarily developed for use by the Speeduino community, but can be utilised for testing virtually any aftermarket ECU system
+This version is a fork of the Josh Stewarts Speeduino arduistim [https://github.com/speeduino/Ardu-Stim](https://github.com/speeduino/Ardu-Stim) and that one was a fork of the original by David Andruczyk [https://gitlab.com/libreems-suite/ardu-stim](https://gitlab.com/libreems-suite/ardu-stim) and is intended to provide a more modern, cross platform GUI as well as continued expansion of the trigger pattern library. It was primarily developed for use by the Speeduino community, but can be utilised for testing virtually any aftermarket ECU system. Dale Follett of Twisted Builds LLC has customized this fork for use with the Twisted Builds LLC version of the engine simulator, and have added multiple wheel patterns as requested by customers and users. If you are on any other software version of this ardu-stim software, please feel free to copy/paste any of the wheel patterns I have added and use them as you see fit. There is no guarentee on any of the wheels used or added to this code base, however at time of upload they appear to be correct. Please use and test at your own risk.
 
 ## Wiring
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 <div align="center">
 
-<img src="https://github.com/speeduino/wiki.js/raw/master/img/Speeduino%20logo_med.png" alt="Speeduino" width="600" />
-
-[![Release](https://img.shields.io/github/release/speeduino/Ardu-Stim.svg)](https://github.com/speeduino/Ardu-Stim/releases/latest)
-[![License](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://github.com/speeduino/Ardu-Stim/blob/master/LICENSE)
-[![Chat on Slack](https://img.shields.io/badge/slack-speeduino-CC2B5E.svg?style=flat&logo=slack)](https://speeduino.com/home/community/slack)
-
-##### This is the Speeduino fork of the ardustim engine simulator.
+##### This is the Twisted Builds LLC fork of the Speeduino fork of the ardustim engine simulator.
 </div>
 
 ## Ardustim

--- a/ardustim/ardustim/ardustim.ino
+++ b/ardustim/ardustim/ardustim.ino
@@ -88,6 +88,7 @@ wheels Wheels[MAX_WHEELS] = {
   { six_g_seventy_two_with_cam_friendly_name, six_g_seventy_two_with_cam, 0.6, 144, 720 },
   { buell_oddfire_cam_friendly_name, buell_oddfire_cam, 0.33333, 80, 720 },
   { gm_ls1_crank_and_cam_friendly_name, gm_ls1_crank_and_cam, 6.0, 720, 720 },
+  { gm_ls_58X_crank_and_4x_cam_friendly_name, GM_LS_58X_crank_and_4x_cam, 1.0, 240, 720},
   { lotus_thirty_six_minus_one_one_one_one_friendly_name, lotus_thirty_six_minus_one_one_one_one, 0.6, 72, 360 },
   { honda_rc51_with_cam_friendly_name, honda_rc51_with_cam, 0.2, 48, 720 },
   { thirty_six_minus_one_with_second_trigger_friendly_name, thirty_six_minus_one_with_second_trigger, 0.6, 144, 720 },

--- a/ardustim/ardustim/ardustim.ino
+++ b/ardustim/ardustim/ardustim.ino
@@ -122,7 +122,8 @@ wheels Wheels[MAX_WHEELS] = {
   { Toyota_4AGZE_friendly_name, toyota_4AGZE, 0.333, 144, 720 },
   { Suzuki_DRZ400_friendly_name, suzuki_DRZ400,0.6, 72, 360},
   { Jeep_2000_friendly_name, jeep_2000, 1.5, 360, 720},
-  { BMW_N20_friendly_name, bmw_n20, 1.0, 240, 720}
+  { BMW_N20_friendly_name, bmw_n20, 1.0, 240, 720},
+  { VIPER9602_friendly_name, viper9602wheel, 1.0, 240, 720},
 };
 
 /* Initialization */

--- a/ardustim/ardustim/ardustim.ino
+++ b/ardustim/ardustim/ardustim.ino
@@ -122,6 +122,7 @@ wheels Wheels[MAX_WHEELS] = {
   { Toyota_4AGZE_friendly_name, toyota_4AGZE, 0.333, 144, 720 },
   { Suzuki_DRZ400_friendly_name, suzuki_DRZ400,0.6, 72, 360},
   { Jeep_2000_friendly_name, jeep_2000, 1.5, 360, 720},
+  { BMW_N20_friendly_name, bmw_n20, 1.0, 240, 720}
 };
 
 /* Initialization */

--- a/ardustim/ardustim/defines.h
+++ b/ardustim/ardustim/defines.h
@@ -24,7 +24,7 @@
 /* defines */
 #define SWEEP_ISR_RATE 1000
 #define TMP_RPM_SHIFT 4 /* x16, 0-16384 RPM via pot */
-#define TMP_RPM_CAP 16384 /* MAX RPM via pot control */
+#define TMP_RPM_CAP 9000 /* MAX RPM via pot control. Adjusted to 9,000rpm max from 16,384rpm to match the GUI */
 #define FACTOR_THRESHOLD 1000000
 #define MORE_LINEAR_SWEEP 1
 #define SUI_NO_INCLUDE_EXTRA_SAFETYCHECKS

--- a/ardustim/ardustim/wheel_defs.h
+++ b/ardustim/ardustim/wheel_defs.h
@@ -132,6 +132,7 @@
    TOYOTA_4AGZE,           /*Toyota 4AGZE, 24 teeth and one cam tooth*/
    SUZUKI_DRZ400,         /* Suzuki DRZ-400 6 coil "tooths", 2 uneven crank tooths */
    JEEP2000,  /* Jeep 4.0 6cyl aka jeep2000 */
+   BMW_N20, //BMW N20 58x and custom cam wheels
    MAX_WHEELS,
  }WheelType;
 
@@ -195,6 +196,7 @@
  const char Toyota_4AGZE_friendly_name[] PROGMEM = "Toyota 4AGZE";
  const char Suzuki_DRZ400_friendly_name[] PROGMEM = "Suzuki DRZ400";
  const char Jeep_2000_friendly_name[] PROGMEM = "Jeep 2000";
+ const char BMW_N20_friendly_name[] PROGMEM = "BMW N20";
 
  /* Very simple 50% duty cycle */
  const unsigned char dizzy_four_cylinder[] PROGMEM = 
@@ -1395,6 +1397,34 @@
      0,0,0,0,0,0,0,1,0,0,  /* Degrees 660-680. Tooth #19 at 674* for 2* duration */
      0,0,0,0,0,0,0,1,0,0,  /* Degrees 680-700. Tooth #20 at 694* for 2* duration */
      0,0,0,0,0,0,0,1,0,0  /* Degrees 700-720. Tooth #21 at 714* for 2* duration */
+   };
+
+   const unsigned char bmw_n20[] PROGMEM = 
+   { 
+     1,0,1,0,1,0,1,0,1,0, //Crank teeth 1-5 (TDC Cylinder 1, first tooth after missing)
+     1,0,1,0,1,0,1,0,1,0, //Crank teeth 6-10
+     1,0,1,0,1,0,1,0,1,0, //Crank teeth 11-15
+     7,6,7,6,7,6,7,6,7,6, //Crank teeth 16-20, both camshaft signals high
+     7,6,7,6,7,6,1,0,1,0, //Crank teeth 21-25, both camshaft signals high until last two teeth, then low
+     1,0,1,0,1,0,1,0,1,0, //Crank teeth 26-30
+     1,0,1,0,1,0,1,0,1,0, //Crank teeth 31-35
+     1,0,1,0,1,0,1,0,1,0, //Crank teeth 36-40
+     1,0,1,0,1,0,1,0,1,0, //Crank teeth 41-45
+     7,6,7,6,7,6,7,6,7,6, //Crank teeth 46-50, both camshaft signals high for 180* (30 teeth)
+     7,6,7,6,7,6,7,6,7,6, //Crank teeth 51-55
+     7,6,7,6,7,6,6,6,6,6, //Crank teeth 56-60 - last two teeth missing
+     7,6,7,6,7,6,7,6,7,6, //Crank teeth 1-5
+     7,6,7,6,7,6,7,6,7,6, //Crank teeth 6-10
+     7,6,7,6,7,6,7,6,7,6, //Crank teeth 11-15
+     1,0,1,0,1,0,1,0,1,0, //Crank teeth 16-20 cam signals low
+     1,0,1,0,7,6,7,6,7,6, //Crank teeth 21-25 cam signals low then back high
+     7,6,7,6,7,6,7,6,7,6, //Crank teeth 26-30
+     7,6,7,6,7,6,7,6,7,6, //Crank teeth 31-35
+     7,6,7,6,7,6,7,6,7,6, //Crank teeth 36-40
+     7,6,7,6,7,6,7,6,7,6, //Crank teeth 41-45
+     1,0,1,0,1,0,1,0,1,0, //Crank teeth 46-50
+     1,0,1,0,1,0,1,0,1,0, //Crank teeth 51-55
+     1,0,1,0,1,0,0,0,0,0, //Crank teeth 56-60 - last two teeth missing
    };
 
 

--- a/ardustim/ardustim/wheel_defs.h
+++ b/ardustim/ardustim/wheel_defs.h
@@ -98,6 +98,7 @@
    SIX_G_SEVENTY_TWO_WITH_CAM, /* Mitsubishi DOHC CAS and TCDS 6G72 */
    BUELL_ODDFIRE_CAM,     /* Buell 45 deg cam wheel */
    GM_LS1_CRANK_AND_CAM,  /* GM LS1 24 tooth with cam */
+   GM_58x_LS_CRANK_4X_CAM, /* GM 58x LS crank 4x cam wheel */
    LOTUS_THIRTY_SIX_MINUS_ONE_ONE_ONE_ONE, /* Lotus crank wheel 36-1-1-1-1 */
    HONDA_RC51_WITH_CAM,   /* Honda oddfire 90 deg V-twin */
    THIRTY_SIX_MINUS_ONE_WITH_SECOND_TRIGGER, /* From jimstim */
@@ -160,6 +161,7 @@
  const char six_g_seventy_two_with_cam_friendly_name[] PROGMEM = "Mitsubishi 6g72 with cam";
  const char buell_oddfire_cam_friendly_name[] PROGMEM = "Buell Oddfire CAM wheel";
  const char gm_ls1_crank_and_cam_friendly_name[] PROGMEM = "GM LS1 crank and cam";
+ const char gm_ls_58X_crank_and_4x_cam_friendly_name[] PROGMEM = "GM 58x crank and 4x cam";
  const char lotus_thirty_six_minus_one_one_one_one_friendly_name[] PROGMEM = "Odd Lotus 36-1-1-1-1 flywheel";
  const char honda_rc51_with_cam_friendly_name[] PROGMEM = "Honda RC51 with cam";
  const char thirty_six_minus_one_with_second_trigger_friendly_name[] PROGMEM = "36-1 crank with 2nd trigger on teeth 33-34";
@@ -621,6 +623,35 @@
       2,2,2,2,2,2,2,2,2,2,2,2,3,3,3,2,2,2,2,2,
       2,2,2,2,2,2,2,3,3,3,2,2,2,2,2,2,2,2,2,2,
       2,2,3,3,3,2,2,2,2,2,2,2,2,2,2,2,2,3,3,3,
+    };
+
+ //Added by Dale Follett of Twisted Builds LLC for GM gen4 LS 58x 4x crank cam simulation.
+ const unsigned char GM_LS_58X_crank_and_4x_cam[] PROGMEM = 
+    { //58x LS crank 4x LS cam
+      1,0,1,0,3,2,3,2,3,2, //1-5
+      3,2,3,2,3,2,1,0,1,0, //6-10
+      1,0,1,0,1,0,1,0,1,0, //11-15
+      1,0,1,0,1,0,1,0,1,0, //16-20
+      1,0,1,0,1,0,1,0,1,0, //21-25
+      1,0,1,0,1,0,1,0,1,0, //26-30
+      1,0,1,0,3,2,3,2,3,2, //31-35
+      3,2,3,2,3,2,1,0,1,0, //36-40
+      1,0,1,0,3,2,3,2,3,2, //41-45
+      3,2,3,2,3,2,3,2,3,2, //46-50
+      3,2,3,2,3,2,3,2,3,2, //51-55
+      3,2,3,2,3,2,2,2,2,2, //56-60 - First crank revolution, last two crank teeth missing
+      3,2,3,2,3,2,3,2,3,2, //61-65
+      3,2,3,2,3,2,1,0,1,0, //66-70
+      1,0,1,0,3,2,3,2,3,2, //71-75
+      3,2,3,2,3,2,3,2,3,2, //76-80
+      3,2,3,2,3,2,3,2,3,2, //81-85
+      3,2,3,2,3,2,3,2,3,2, //86-90
+      3,2,3,2,3,2,3,2,3,2, //91-95
+      3,2,3,2,3,2,1,0,1,0, //96-100
+      1,0,1,0,1,0,1,0,1,0, //101-105
+      1,0,1,0,1,0,1,0,1,0, //106-110
+      1,0,1,0,1,0,1,0,1,0, //111-115
+      1,0,1,0,1,0,0,0,0,0, //116-120
     };
   
  /* Lotus 36-1-1-1-1 wheel, missing teeth at

--- a/ardustim/ardustim/wheel_defs.h
+++ b/ardustim/ardustim/wheel_defs.h
@@ -133,6 +133,7 @@
    SUZUKI_DRZ400,         /* Suzuki DRZ-400 6 coil "tooths", 2 uneven crank tooths */
    JEEP2000,  /* Jeep 4.0 6cyl aka jeep2000 */
    BMW_N20, //BMW N20 58x and custom cam wheels
+   VIPER_96_02, // Dodge Viper 1996-2002 wheel pattern
    MAX_WHEELS,
  }WheelType;
 
@@ -197,6 +198,7 @@
  const char Suzuki_DRZ400_friendly_name[] PROGMEM = "Suzuki DRZ400";
  const char Jeep_2000_friendly_name[] PROGMEM = "Jeep 2000";
  const char BMW_N20_friendly_name[] PROGMEM = "BMW N20";
+ const char VIPER9602_friendly_name[] PROGMEM = "Dodge Viper V10 1996-2002";
 
  /* Very simple 50% duty cycle */
  const unsigned char dizzy_four_cylinder[] PROGMEM = 
@@ -1425,6 +1427,40 @@
      1,0,1,0,1,0,1,0,1,0, //Crank teeth 46-50
      1,0,1,0,1,0,1,0,1,0, //Crank teeth 51-55
      1,0,1,0,1,0,0,0,0,0, //Crank teeth 56-60 - last two teeth missing
+   };
+
+   const unsigned char viper9602wheel[] PROGMEM = 
+   // Viper pattern has 10 total crank teeth that are on shortly in pairs. Cam is high for 360* of crank then low for the next 360* of crank
+   // This pattern was added by Dale Follett of Twisted Builds LLC going off a supplied oscilloscope image of the wheel pattern. Due to this
+   // There is no guarentees on this wheel pattern as of 3/24/2024 and this pattern should be used at your own risk. However it should be correct.
+   // I'm basing this using percentages. 120 total "edges" but should duplicate the factory wheels. Will test with o-scope.
+   {
+      //Cam on this revolution
+      2,2,2,2,2,2,3,3,2,2, //1-5
+      2,2,3,3,2,2,2,2,2,2, //6-10
+      2,2,2,2,2,2,2,2,2,2, //11-15
+      3,3,2,2,2,2,3,3,2,2, //16-20
+      2,2,2,2,2,2,2,2,2,2, //21-25
+      2,2,2,2,3,3,2,2,2,2, //26-30
+      3,3,2,2,2,2,2,2,2,2, //31-35
+      2,2,2,2,2,2,2,2,3,3, //36-40
+      2,2,2,2,3,3,2,2,2,2, //41-45
+      2,2,2,2,2,2,2,2,2,2, //46-50
+      2,2,3,3,2,2,2,2,3,3, //51-55
+      2,2,2,2,2,2,2,2,2,2, //56-60
+      //Cam off this revolution
+      0,0,0,0,0,0,1,1,0,0, //1-5
+      0,0,1,1,0,0,0,0,0,0, //6-10
+      0,0,0,0,0,0,0,0,0,0, //11-15
+      1,1,0,0,0,0,1,1,0,0, //16-20
+      0,0,0,0,0,0,0,0,0,0, //21-25
+      0,0,0,0,1,1,0,0,0,0, //26-30
+      1,1,0,0,0,0,0,0,0,0, //31-35
+      0,0,0,0,0,0,0,0,1,1, //36-40
+      0,0,0,0,1,1,0,0,0,0, //41-45
+      0,0,0,0,0,0,0,0,0,0, //46-50
+      0,0,1,1,0,0,0,0,1,1, //51-55
+      0,0,0,0,0,0,0,0,0,0, //56-60
    };
 
 


### PR DESCRIPTION
Adjusted TMP_RPM_CAP to 9000rpm. This makes the adjustable RPM using the potentiometer the same as the GUI interface. Also found when maxing out the physical potiemeter knob for RPM that the stim would stay at max RPM value and not return down with the knob when the knob was physically adjusted down. Adjusting the TMP_RPM_CAP to match the GUI maximum displayable RPM fixed that bug.